### PR TITLE
Use Splunk auth rather than default

### DIFF
--- a/internal/app/cmd/backup/dashboard.go
+++ b/internal/app/cmd/backup/dashboard.go
@@ -56,7 +56,8 @@ func (c *Cmd) Dashboard(cmd *cobra.Command, args []string) {
 
 		config.CLI.Prompt(".")
 
-		filenamexml := filepath.Join(folder, fmt.Sprintf("%s.xml", d.Name))
+                os.MkdirAll(filepath.Join(folder, fmt.Sprintf("%s", d.AppName)), 0777)
+                filenamexml := filepath.Join(folder, fmt.Sprintf("%s", d.AppName), fmt.Sprintf("%s.xml", d.Name))
 		c.writeContent(d.Content, filenamexml)
 		c.touchFile(filenamexml, d.Updated)
 

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -107,7 +107,7 @@ func (s *Service) Login(u string, username string, password string, cookiePort s
 }
 
 func (s *Service) step1(u string) (string, string, error) {
-	var url = u + "account/login?return_to=/en-US/"
+	var url = u + "account/login?return_to=/en-US/&loginType=splunk"
 
 	client, req, err := s.authGetRequest(url)
 	if err != nil {


### PR DESCRIPTION
This is fantastic work!
Just a quick tweak from me, we use SAML auth by default which means the default login page redirects to our SAML provider.
I've added `loginType=splunk` to the login URL to force the Splunk login flow which allows gives us the Splunk login boxes needed to run this.
