### PR TITLE
Create App-specific dashboard folders

### DIFF
--- a/internal/app/cmd/backup/dashboard.go
+++ b/internal/app/cmd/backup/dashboard.go
@@ -53,7 +53,9 @@ func (c *Cmd) Dashboard(cmd *cobra.Command, args []string) {
 	for d := range chand {
 		config.CLI.Prompt(".")
 
-		filenamexml := filepath.Join(folder, fmt.Sprintf("%s.xml", d.Name))
+                os.MkdirAll(filepath.Join(folder, fmt.Sprintf("%s", d.App)), 0777)
+
+		filenamexml := filepath.Join(folder, fmt.Sprintf("%s", d.App), fmt.Sprintf("%s.xml", d.Name))
 		c.writeContent(d.Content, filenamexml)
 		c.touchFile(filenamexml, d.Updated)
 

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -107,7 +107,7 @@ func Login(u string, username string, password string, cookiePort string, log *l
 }
 
 func step1(u string) (string, string, error) {
-	var url = u + "account/login?return_to=%2Fen-US%2F"
+	var url = u + "account/login?return_to=%2Fen-US%2F&loginType=splunk"
 
 	client, req, err := authGetRequest(url)
 	if err != nil {

--- a/pkg/service/dashboard.go
+++ b/pkg/service/dashboard.go
@@ -18,6 +18,7 @@ type Dashboard struct {
 	Owner    string
 	Content  string
 	RawEntry string //json returned from the call that built it.
+        App      string //Name of the app the dash originates
 }
 
 // ListDashboard returns ALL dashboards returns an array of dasboards from the call
@@ -82,7 +83,7 @@ func translateDashboard(body *[]byte, chand chan Dashboard) (total int, count in
 			log.Fatalf("JSON marshal unexpected error")
 		}
 		d.RawEntry = string(bb)
-
+                d.App = e.Content.EaiAppName
 		chand <- d
 	}
 


### PR DESCRIPTION
I'm wanting to use this app for backing up local copies of dashboards for specific apps, by putting each dashboard in an app-specific folder it is much easier to manage this.